### PR TITLE
Fix 'useless' setTimeout call

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -1444,7 +1444,7 @@ function doPostformChanges() {
 		var load = nav.Opera ? 'DOMFrameContentLoaded' : 'load';
 		$after($id('DESU_content'), [
 			$add('<iframe name="DESU_iframe" id="DESU_iframe" src="about:blank" />', {
-				load: function(e) { setTimeout(iframeLoad(e.target), 0); }
+				load: function(e) { setTimeout(function() { iframeLoad(e.target); }, 0); }
 			}
 		)]);
 		$rattr($attr(pr.form, {'target': 'DESU_iframe'}), 'onsubmit');


### PR DESCRIPTION
Консоль ошибок в Firefox'e:

<pre>Timestamp: 26.01.2012 5:28:36
Error: useless setTimeout call (missing quotes around argument?)
Source File: chrome://scriptish/content/scriptish.js -> file:///C:/Users/Y0ba/AppData/Roaming/Mozilla/Firefox/Profiles/1024lx5o.default/scriptish_scripts/dollchanextensiontools@httpwwwfreedollchanorgscripts/dollchanextensiontools@httpwwwfreedollchanorgscripts.user.js
Line: 1447</pre>
