### PR TITLE
Проблема с прикреплёнными к посту торрентами

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -1932,7 +1932,8 @@ function getImgWeight(post) {
 
 function getImgSize(post) {
 	var el = getImgInfo(post)
-	return el ? el.textContent.match(/\d+[x×]\d+/)[0].split(/[x×]/) : [null, null];
+	var m = el ? el.textContent.match(/\d+[x×]\d+/) : null;
+	return m ? m[0].split(/[x×]/) : [null, null];
 }
 
 function getText(el) {


### PR DESCRIPTION
Если к посту прикреплён, например, торрент, а не картинка, то скрипт падает, не обнаружив текста вида ШИРИНАxВЫСОТА (очевидно, что у торрента нет ширины и высоты).
Коммит 5db46527 исправляет данную проблему.
