### PR TITLE
Скрытие по названию видео

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -265,6 +265,7 @@ quotetxt = '',
 docTitle, favIcon, favIconInt, isActiveTab = false, isExpImg = false,
 timePattern, timeRegex,
 oldTime, endTime, timeLog = '',
+tubeHidTimeout,
 storageLife = 5*24*3600*1000,
 homePage = 'http://www.freedollchan.org/scripts/';
 
@@ -2112,7 +2113,7 @@ function addLinkTube(post) {
 }
 
 function filterTextTube(post, text) {
-	var fHide = (function(a){if(a) return hidePost; else return function(b,c){}})(Cfg.spells), i = 0, t;
+	var fHide = (function(a){if(a) return hidePost; else return function(b,c){}})(Cfg.spells === 1), i = 0, t, post;
 	for(;t = oSpells.video[i++];)
 		if(strToRegexp(t).test(text)) {
 			fHide(post, '#video ' + t);


### PR DESCRIPTION
Добавляет выражение `#video` для скрытия постов по названию видео. Учитывая то, что названия загружаются асинхронно, пришлось делать отдельные функции:
-   `filterTextTube` - вызывается после каждого загруженного названия и сверяет, подходит ли название под регулярные выражения. Если да, то помечает, что пост надо скрыть (вызывает `hidePost`), помечает, что пост скрыт с помощью выражения `#video` и если в течении 500мс не будет загружен ни один заголовок, скрывает все помеченные посты.
-   `unHideTextTube` - отображает помеченные посты. Вызывается при удалении/отключении выражений.
-   `hideTextTube` - скрывает посты по названию видео (предполагается, что все названия уже загружены). Вызывается при добавлении/включении выражений.
