### PR TITLE
Улучшение совместимости с некоторыми бордами

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -2691,8 +2691,7 @@ function doPostFilters(post) {
 }
 
 function togglePostVisib(post) {
-	post.Vis = post.Vis !== 0 ? 0 : 1;
-	setPostVisib(post, post.Vis);
+	setPostVisib(post, post.Vis !== 0 ? 0 : 1);
 	savePostsVisib();
 }
 


### PR DESCRIPTION
Патч позволяет скрипту брать номера тредов и постов из свойства Num, которое теперь универсальное. К самим постам вместо изменения id просто добавляется класс, что позволяет полностью сохранить совместимость со встроенными в борду скриптами (например скрипт в краутчане для подсветки поста, если в uri есть `#номер_поста`). Алсо немного ускоряется работа скрипта из-за того, что теперь для построения карты ответов не надо всё время выдирать номер поста из id при помощи регексов.
