### PR TITLE
Изменение логики скрытия постов

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -2371,7 +2371,7 @@ function showPostPreview(e) {
 	pView.Num = pNum;
 	if(post) {
 		funcPostPreview(post, parentId);
-		if(!post.Vis) togglePost(pView);
+		if(post.Vis === 0) togglePost(pView);
 	} else {
 		funcPostPreview(null, null, '<span class="DESU_icn_wait">&nbsp;</span>' + Lng.loading);
 		AJAX(null, b, tNum, function(err) {


### PR DESCRIPTION
Патч содержит следующие изменения:
-    В `DESU_Posts_` сохраняются посты, скрытые пользователем.
-    В `DESU_Threads_` сохраняются треды скрытые как пользователем, так и скриптом.
-    В `DESU_Filtered_` сохраняется состояние всех постов в определённом треде. Используется формат XXXXXXX-YYYYYYYYYYYYY..., где XXXXXXX - номер треда, YYYY... - видимость постов (1 или 0) в порядке, в котором они расположены в треде. Используется для оптимизации скрытия постов в треде.
-    Теперь если пользователь раскрыл пост, скрипт его больше не скроет при помощи спеллов или анти-вайпа.

Ах да, формат сохранения не совместим с предыдущим.
