### PR TITLE
Небольшое исправление

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -1622,7 +1622,7 @@ function prepareFiles(el, fn) {
 		var bb = new MozBlobBuilder();
 		bb.append(e.target.result);
 		bb.append(String(Math.round(Math.random() * 1000)));
-		fn(bb.getBlob(pr.file.files[0].type));
+		fn(bb.getBlob(file.type));
 	};
 }
 


### PR DESCRIPTION
Любому файлу из списка всегда даётся тип первого файла. Из-за этого на краутчане добавление байта может теоретически не заработать (хотя ему по-моему на MIME-тип пофигу).
