### PR TITLE
Фикс для prepareData

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -1744,7 +1744,7 @@ function prepareData(fn) {
 		if(el.type === 'file') {
 			prepareFiles(el, function(blob) { if(blob != null) fd.append(el.name, blob); ready++; cb(); });
 			rNeeded++;
-		} else if(el.type === 'checkbox' && el.name === 'sage') { if(el.checked) fd.append(el.name, el.value); }
+		} else if(el.type === 'checkbox') { if(el.checked) fd.append(el.name, el.value); }
 		else fd.append(el.name, el.value);
 	});
 	done = true;


### PR DESCRIPTION
Если сажа являлась чекбоксом, скрипт всегда отправлял её (если включить добавление байта в изображение). Данный патч исправляет такое поведение.
