### PR TITLE
Замена innerHTML на замещение ноды

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -4236,9 +4236,7 @@ function getFullMsg(post, tNum, a, addFunc) {
 			$del(a);
 			post.Msg = $html(post.Msg, aib.getMsg(importPost(brd, post.Num)).innerHTML);
 			post.Text = getText(post.Msg);
-			if(addFunc) {
-				processFullMsg(post);
-			}
+			processFullMsg(post);
 		}
 	});
 }


### PR DESCRIPTION
Алсо, убрал `processFullMsg` при автоматическом раскрытии для ханабиры. Всё равно в этом случае все функции встраиваются в другом месте.
