### PR TITLE
Фикс для tinyboard и 420chan

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -6291,6 +6291,9 @@ function parseDelform(node, dc, tFn, pFn) {
 	var i, len, op, post, psts;
 	$$Del('.//script', node, dc);
 	forEachThread(node, dc, function(thr) {
+		if(aib._420 || (aib.tiny && !TNum)) {
+			$after(thr, thr.lastChild);
+		}
 		op = aib.getOp(thr, dc);
 		if(aib.brit) {
 			$before($t('blockquote', op), [$new('div', null, null), post = $new('br', null, null)]);


### PR DESCRIPTION
На самом деле эта конструкция использется для того, чтобы вытащить `br` (420chan) `hr` (tinyboard) за пределы элемента-треда иначе после разворота треда они пропадут. В 420chan'e лишний `br` есть и на странице треда, если его не вынести за пределы, то подзагруженные посты будут ниже тех, что были изначально.
