### PR TITLE
Новый аплоад html5

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -2630,7 +2630,7 @@ function doPostformChanges() {
 		setTimeout(doSageBtn, 0);
 	}
 	if(Cfg.verify !== 0) {
-		if(nav.Firefox > 6 || nav.Chrome || nav.Opera >= 11.1) {
+		if(!aib.nul && (nav.Firefox > 6 || nav.Chrome || nav.Opera >= 11.1)) {
 			pr.form.onsubmit = function(e) {
 				$pd(e);
 				setTimeout(function() {


### PR DESCRIPTION
#138 сюда уже включён, так что мерж ли после него, либо #138 можешь вообще не мержить.

Собственно так. Отключил на нульче - что только не перепробовал, результат - "Flood detected". Думается мне, что из-за порядка заголовков в запросе.
Скрипт:

<pre>POST /board.php?dir=b HTTP/1.1
Host: www.0chan.ru
User-Agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:15.0) Gecko/15.0 Firefox/15.0a1
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Type: multipart/form-data; boundary=---------------------------35581564998
Referer: http://www.0chan.ru/b/res/10259603.html
Content-Length: 31039
Cookie: kustyle_site=Autumn; kustyle=Autumn; postpassword=36662432; disclaimer=1; mm2=1; mm=2442429030; PHPSESSID=n12dqspdmta40i1i0tf1mfdeh1; cap=31b634752ba687e4cc6c58b3e3e52e8b
Pragma: no-cache
Cache-Control: no-cache</pre>


Браузер:

<pre>POST /board.php?dir=b HTTP/1.1
Host: www.0chan.ru
User-Agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:15.0) Gecko/15.0 Firefox/15.0a1
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-us,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive
Referer: http://www.0chan.ru/b/res/10259603.html
Cookie: kustyle_site=Autumn; kustyle=Autumn; postpassword=36662432; disclaimer=1; mm2=1; mm=2681814527; PHPSESSID=n12dqspdmta40i1i0tf1mfdeh1; cap=31b634752ba687e4cc6c58b3e3e52e8b
Content-Type: multipart/form-data; boundary=---------------------------41184676334
Content-Length: 31168</pre>

На boundary и Cookie не обращай внимание - они всегда разные.

Алсо, как прочитал здесь: http://dobrochan.ru/lor/res/52762.xhtml там не работают даже некоторые ванильные браузеры. Так что, тут проблемы у них.
