### PR TITLE
Замена http на https в youtube-ссылках

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -2429,17 +2429,6 @@ function doChanges() {
 				$del(el);
 			}
 		}
-		$event(window, {
-			'load': function() {
-				setTimeout(function() {
-					if(aib.nul) {
-						$Del('.//div[@class="replieslist"]', dForm);
-					} else {
-						$Del('.//small[starts-with(@id,"rfmap")]|.//i[@class="abbrev"]', dForm);
-					}
-				}, 0);
-			}
-		});
 	}
 	if(TNum) {
 		initThreadsUpdater();
@@ -5925,7 +5914,8 @@ function scriptCSS() {
 		a[href="#"] { text-decoration: none !important; outline: none; }\
 		.DESU_pPost { font-weight: bold; }\
 		.DESU_info { padding: 3px 6px !important; }\
-		.DESU_pView { position: absolute; width: auto; min-width: 0; z-index: 9999; opacity: 0; border: 1px solid grey; }'
+		.DESU_pView { position: absolute; width: auto; min-width: 0; z-index: 9999; opacity: 0; border: 1px solid grey; }\
+		.replieslist, .abbrev, small[id^="rfmap"] { display: none !important; }'
 	);
 	if(Cfg.delhd === 2) {
 		x.push('div[id^=DESU_hidThr_], div[id^=DESU_hidThr_] + div + br, div[id^=DESU_hidThr_] + div + br + hr { display: none; }');


### PR DESCRIPTION
Куклоскрипт заботится о приватности пользователей, ага. Алсо, теперь добавляется простой эмбеддер, если `video`-тэг не поддреживается браузером.

Ах да, пробовал заменять src для `video`-тэга. Не выходит.
