### PR TITLE
Упрощение getRefMap

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -2167,9 +2167,6 @@ function selectImgSearch(btn, href) {
 ==============================================================================*/
 
 function keyNavTrigger(node) {
-	if(!node) {
-		return;
-	}
 	$each($X('.//input[@type="text" or @type="password"]|.//textarea', node), function(el) {
 		el.onfocus = function() {
 			isKeyNav = false;
@@ -2239,7 +2236,7 @@ function initKeyNavig() {
 			} catch(e) {}
 		};
 
-	keyNavTrigger(pr.form);
+	keyNavTrigger(doc);
 
 	window.onscroll = function() {
 		if(!scrScroll) {


### PR DESCRIPTION
`Null`-проверку убрал, ибо этот баг появляется только в бете-оперы. Да и всё равно только её недостаточно.
