### PR TITLE
Фикс для айфрейма

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -608,11 +608,6 @@ function fixFunctions() {
 			return str.slice(0, i + 1);
 		};
 	}
-	if(!Date.now) {
-		Date.now = function now() {
-			return +(new Date);
-		};
-	}
 	if(typeof uneval !== 'function') {
 		(function(){var f=[],g={"\t":"t","\n":"n","\u000b":"v","\u000c":"f","\r":"\r","'":"'",'"':'"',"\\":"\\"},h=function(b){if(b in g)return"\\"+g[b];var c=b.charCodeAt(0);return c<32?"\\x0"+c.toString(16):c<127?"\\"+b:c<256?"\\x"+c.toString(16):c<4096?"\\u0"+c.toString(16):"\\u"+c.toString(16)},i=function(b){return b.toString()},j={"boolean":i,number:i,string:function(b){return"'"+b.toString().replace(/[\x00-\x1F\'\"\\\u007F-\uFFFF]/g,h)+"'"},undefined:function(){return"undefined"},"function":i}, k=function(b,c){var a=[],d;for(d in b)b.hasOwnProperty(d)&&(a[a.length]=uneval(d)+":"+uneval(b[d],1));return c?"{"+a.toString()+"}":"({"+a.toString()+"})"},uneval_set=function(b,c,a){f[f.length]=[b,c];j[c]=a||k};uneval_set(Array,"array",function(b){for(var c=[],a=0,d=b.length;a<d;a++)c[a]=uneval(b[a]);return"["+String(c)+"]"});uneval_set(RegExp,"regexp",i);uneval_set(Date,"date",function(b){return"(new Date("+b.valueOf()+"))"});window.uneval=function(b,c){var a;if(b===void 0)a="undefined";else if(b===null)a= "null";else{a:if(a=typeof b,a=="object"){a=0;for(var d=f.length;a<d;a++)if(b instanceof f[a][0]){a=f[a][1];break a}a="object"}a=(j[a]||k)(b,c)}return a}})();
 	}
@@ -6809,6 +6804,11 @@ function preparePage() {
 ==============================================================================*/
 
 function doScript() {
+	if(!Date.now) {
+		Date.now = function now() {
+			return +(new Date);
+		};
+	}
 	var initTime = Date.now();
 	oldTime = initTime;
 	if(!isCompatible()) {


### PR DESCRIPTION
Перенёс код для изменения размера в единый с кнопками `EventListener`. Плюс айфрейм не показывался, если была включена проверка обновлений при каждом открытии страницы и было доступно обновление.
