### PR TITLE
Фикс для genRefMap & updRefMap

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -3806,9 +3806,7 @@ function addImgSearch(el) {
 
 function expandPostImg(a, post, isExp) {
 	if(/\.jpe?g|\.png|.\gif|^blob:/i.test(a.href)) {
-		addFullImg(a, getImgSize(
-			post.Img.snapshotLength > 1 ? $x('ancestor::node()[self::div or self::td][1]', a) : post
-		), isExp);
+		addFullImg(a, getImgSize(aib.getPicWrap(a)), isExp);
 	}
 }
 


### PR DESCRIPTION
Оказывается опира - единственный "современный" браузер, который не может в `Object.keys` (в стандарте этот метод был определён 3 (!) года назад). http://kangax.github.com/es5-compat-table/
Если этот фикс не работает, то замени `obj.hasOwnProperty(i)` обратно на `typeof obj[i] === 'object'`. Лисо и хромобоги не должны страдать из-за недобраузеров.

`refMap` я вынес в основное пространство, ибо мне он нужен для реализации одной фичи. При этом он всё так же очищается после каждого использования.
