### PR TITLE
Неправильно определялись пропущенные посты

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -6708,11 +6708,6 @@ function replaceDelform(el) {
 
 function preparePage() {
 	var el;
-	/*$Del('preceding-sibling::node()[preceding-sibling::*[descendant-or-self::*[' + (
-		aib.abu ? 'self::form'
-		: aib.fch ? 'self::div[@class="boardBanner"]'
-		: 'self::div[@class="logo"]'
-	) + ' or self::h1]]]', dForm);*/
 	if(aib.krau) {
 		$del($t('hr', dForm));
 		$del($t('hr', dForm.previousElementSibling));
@@ -6752,6 +6747,11 @@ function initUpdater() {
 			return false;
 		}
 	}
+	$Del('preceding-sibling::node()[preceding-sibling::*[descendant-or-self::*[' + (
+		aib.abu ? 'self::form'
+		: aib.fch ? 'self::div[@class="boardBanner"]'
+		: 'self::div[@class="logo"]'
+	) + ' or self::h1]]]', dForm);
 	if(TNum) {
 		var onhid = function() {
 			doc.body.className = 'blurred';


### PR DESCRIPTION
Плюс разделил `preparePage` на две части.

Точнее определялись-то правильно, однако для избежания утечек лучше использовать локальную переменную.
