### PR TITLE
Удаляем мусор из файлов если пользователь создаёт rarJPEG

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -5547,7 +5547,7 @@ function detectWipe_longWords(txt) {
 	var i = 0,
 		words = txt.replace(/https*:\/\/.*?(\s|$)/g, '').replace(/[\s\.\?!,>:;-]+/g, ' ').split(' '),
 		len = words.length;
-	return words[0] > 50 || (len > 1 && words.join('').length / len > 10) ? 'long words' : false;
+	return words[0].length > 50 || (len > 1 && words.join('').length / len > 10) ? 'long words' : false;
 }
 
 function detectWipe_caseWords(txt) {


### PR DESCRIPTION
Архиватор понимает только первый встреченный им архив, так что если пользователь попытается создать рарЖпег с картинки, уже содержащей архив, получится хуйня. Данный патч исправляет эту проблему.
