### PR TITLE
Исправления

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -6085,7 +6085,7 @@ function scriptCSS() {
 		x += 'img[id^="translate_button"], img[src$="button-expand.gif"], img[src$="button-close.gif"]' + (liteMode ? ', div[id^="disclaimer"]' : '') + ' { display: none !important; }\
 			div[id^="Wz"] { z-index: 10000 !important; }\
 			div[id^="DESU_hidThr_"] { margin-bottom: ' + (!TNum ? '7' : '2') + 'px; }\
-			.file_reply + .DESU_ytObj { margin: 5px 20px 5px 5px;  float: left; }\
+			.file_reply + .DESU_ytObj, .file_thread + .DESU_ytObj { margin: 5px 20px 5px 5px;  float: left; }\
 			.DESU_ytObj + div { clear: left; }';
 	} else if(aib._420) {
 		x += '.opqrbtn, .qrbtn, .ignorebtn, .hidethread, noscript { display: none; }\


### PR DESCRIPTION
1. `sessionStorage` завязан на адресе страницы, поэтому сохранять имя борды и номер треда не имеет смысла.
2. Починил `loadThread`. Теперь он не ломает клавиатурную навигацию.
3. Если надобно, чтобы функция пометки просмотренных постов работала и на доске, то надо сохранять просмотренные посты в постоянное хранилище.
