### PR TITLE
Помещаем скрипт обратно в замыкание

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -6009,6 +6009,7 @@ function scriptCSS() {
 		x += 'color: ' + $getStyle($t('a', doc), 'color') + '; font-size:14px; }\
 			.DESU_btnHide:after { content: "×"; }\
 			.DESU_btnUnhide:after { content: "+"; }\
+			.DESU_btnLock:after { content: "■"; }\
 			.DESU_btnRep:after { content: "R"; }\
 			.DESU_btnExpthr:after { content: "E"; }\
 			.DESU_btnFav:after { content: "F"; }\


### PR DESCRIPTION
Ибо опера (а скоро будет и гризманки) запускает его в области видимости встроенных в страницу скриптов. Видимо какой-то скрипт сосача переопределял функцию `$c`.

<hr>

Кстати, как много юзеров используют фичу объединения постов, учитывая, что до этого патча она работала очень даже хреново (в частности не объединялись посты, скрытые при помощи ютуб-выражений)? Да и сейчас работает хреновенько. Может убрать её совсем? Либо стоит её переделать так, чтобы она не объединяла ОДИН пост, а то `▲[Скрытые посты: 1]` выглядит довольно бесполезно.

<hr>

Плюс исправил нахождение `aib.qTable`. Раньше любая таблица в делформе означала, что эта таблица используется в качестве обёртки поста. Теперь ищется элемент `td` с классом поста. Можно вместо `$q('td.' + aib.cReply, el)` написать `$c(aib.cReply, el).tagName === 'TD'`. Надо будет посмотреть, что быстрее.
