### PR TITLE
Исправление для AJAX-превьюшек

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -4342,7 +4342,7 @@ function showPview(link) {
 				Pviews.ajaxed[b][aib.getPNum(pst)] = pst;
 			}
 			genRefMap(Pviews.ajaxed[b]);
-			if(el && el.ownerDocument) {
+			if(el && el.post.parentNode) {
 				getPview(getAjaxPview(b, pNum), pNum, parent, link, err);
 			}
 		}


### PR DESCRIPTION
Если навести курсор на >>ссылку, а затем убрать его, то превьюшка с загруженным постом появлялась даже если превью с надписью "Загрузка" уже исчезло.
