### PR TITLE
Ускорение replaceDelform

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -4289,7 +4289,7 @@ function getAjaxPview(b, pNum) {
 		return el;
 	}
 	pNum = fixBrd(b) + res + el.thr.Num + (aib.tire ? '.html' : docExt);
-	for(nodes = $T('a', doc), i = nodes.length - 1; i >= 0; i--) {
+	for(nodes = $T('a', el), i = nodes.length - 1; i >= 0; i--) {
 		if(/^>>\d+$/.test(nodes[i].textContent)) {
 			nodes[i].href = pNum;
 		}

--- a/extern.js
+++ b/extern.js
@@ -20,13 +20,6 @@ Document.prototype.implementation.createHTMLDocument = function(html) {};
  */
 String.prototype.contains = function(string, start_index) {};
 /**
- * @param {String} string
- * @param {number=} start_index
- * @return {Boolean}
- * @nosideeffects
- */
-String.prototype.endsWith = function(string, start_index) {};
-/**
  * @param {Function|string} callback
  * @param {number} delay
  * @param {...*} var_args


### PR DESCRIPTION
-20 мс (/int/ краутчана) на моём компьютере. Для некролисоблядей (версия < 11) разницы почти не будет (из-за слоупочного `XMLSerializer`). Для совсем некролисоблядей (версия < 8) разница возможно будет, но в обратную сторону, однако ж.

Алсо, исправляет http://iichan.hk/b/res/2355532.html#2442091
