### PR TITLE
Починка предзагрузки

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -3440,7 +3440,7 @@ function downloadData(url, fn) {
 				return;
 			}
 			if(e.status === 200) {
-				if(aib.fch) {
+				if(nav.Firefox && aib.fch) {
 					fn(new Uint8Array(e.responseText.split('').map(function(a) { return a.charCodeAt(); })));
 				} else {
 					fn(new Uint8Array(e.response));
@@ -3450,12 +3450,12 @@ function downloadData(url, fn) {
 			}
 		}
 	};
-	if(!aib.fch) {
-		obj['responseType'] = 'arraybuffer';
-		$xhr(obj);
-	} else {
+	if(nav.Firefox && aib.fch) {
 		obj['overrideMimeType'] = 'text/plain; charset=x-user-defined';
 		GM_xmlhttpRequest(obj);
+	} else {
+		obj['responseType'] = 'arraybuffer';
+		$xhr(obj);
 	}
 }
 


### PR DESCRIPTION
Итак, на всякий случай объясню в чём была проблема. `$queue` вызывает функцию `endFn` каждый раз когда очередь пуста и происходит последнее событие `end`. В случае с http://iichan.hk/gf/ очередь просто не успевала заполниться из-за того, что на доске много флэш-элементов и мало картинок.

Для хрома теперь событие `end` вызывается после таймаута в 100мс. Изображения будут загружаться чутка медленней, зато не будет тормозить.
