### PR TITLE
Улучшенная предзагрузка изображений

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -3697,7 +3697,7 @@ tubeTitleDownloader.prototype = {
 		sessionStorage['de-yt-titles'] = JSON.stringify(this.ytData);
 	},
 	saveLoaded: function() {
-		this.queue.complete();
+		this.queue && this.queue.complete();
 	},
 	loadTitle: function(data) {
 		var title = this.ytData[data[1]];


### PR DESCRIPTION
Теперь может работать и в опере (без распознавания вложенных файлов, естественно). Плюс добавил автоматическую установку `download` аттрибута, однако возможно стоит сделать его опциональным + сделать так, чтобы на форчане и крауте он проставлял в аттрибут оригинальное имя файла.
