### PR TITLE
Фикс про проверялки абукапчи

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -2814,10 +2814,9 @@ function checkUpload(response) {
 	if(aib.abu) {
 		GM_xmlhttpRequest({
 			'method': 'GET',
-			'url': '/makaba/captcha?code=' + getCookie('usercode') || '',
+			'url': '/makaba/captcha?code=' + (getCookie('usercode') || ''),
 			'onload': function(xhr) {
 				var text = xhr.responseText;
-				console.log(text);
 				if(text.contains('OK') || text.contains('VIP')) {
 					pr.cap = pr.recap = null;
 					updateABUCap();


### PR DESCRIPTION
`getCookie` при отсутствии нужной куки возвращет `false`, на что макаба отправляет ответный код `VIP`, что приводит к скрытию капчи, хотя её ввод в некоторых случаях всё равно требуется.
