### PR TITLE
Исправления

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -7351,7 +7351,7 @@ function processPost(post, pNum, thr, i) {
 	post.msg = $q(aib.qMsg, post);
 	post.img = getPostImages(post);
 	post.sage = aib.getSage(post);
-	post.setAttribute('de-post', pNum);
+	post.setAttribute('de-post', null);
 	pByNum[post.num = pNum] = post;
 }
 


### PR DESCRIPTION
1. Если включить опцию "удалять скрытые посты", то скрытые посты не считались. Т.е. было
   <pre>пост №100
   <скрытый пост №101>
   пост №101</pre>
   после патча
   <pre>пост №100
   <скрытый пост №101>
   пост №102</pre>
2. Исправлена разметка на бордах без изначально размеченных тредов. Алсо `.bind(Fn)` надо заменить на замыкание, либо дропнуть поддержку оперы < `11.6`. В последнем случае можно удалить функции `nav.addClass` и `nav.remClass`.
