### PR TITLE
Улучшение скрытия выделенного

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -7277,7 +7277,7 @@ function getImageboard() {
 		aib.tiny ? '.omitted' :
 		aib.futa ? 'font[color="#707070"]' :
 		aib.krau ? '.omittedinfo' :
-		aib.hana ? '.abbrev' :
+		aib.hana ? '.abbrev > span' :
 		aib.fch ? '.summary.desktop' :
 		'.omittedposts';
 	aib.qTrunc =


### PR DESCRIPTION
Если выделенное находится в пределах темы или сообщения и не содержит переноса строки, используется `#words`, если содержит `#exp`. Если находится за пределами сообщения/темы, используется `#exph`. Стоит заметить, что если выделение затрагивает сразу несколько постов, то релевантный спелл будет добавлен, однако ничего не скроет. Думаю, что проверка того, что выделение находится в пределах одного поста является излишней.
