### PR TITLE
Исправление нотификаций в хроме

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -8650,9 +8650,7 @@ function initThreadUpdater(title, enableUpdater) {
 	if(focused && Cfg['desktNotif'] && ('permission' in Notification)) {
 		switch(Notification.permission.toLowerCase()) {
 		case 'default': requestNotifPermission(); break;
-		case 'denied':
-			notifGranted = false;
-			saveCfg('desktNotif', 0);
+		case 'denied': saveCfg('desktNotif', 0);
 		}
 	}
 


### PR DESCRIPTION
Пиздец, пока додумался, как сделать **КОСТЫЛЬ** покрасивее. В итоге остановился на событии `onerror` для нотификаций. По умолчанию скрипт будет думать, что нотификации показывать можно, однако после первой ошибки (что значит, что их показывать либо запрещено, либо юзер ещё не решал) будет спрашивать разрешение.

`window.focus()` в `onclick` в лисе, кстати, не работает. https://bugzilla.mozilla.org/show_bug.cgi?id=874050

Пиздец вообще. Префиксы поубирали, а сами фичи допиливать до состояния юзабельности не хотят.
