### PR TITLE
Улучшения

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -6798,7 +6798,7 @@ Post.prototype = {
 		}
 	},
 	_removeFullImage: function(e, full, thumb, data) {
-		var pEl, pv, box, x, y, inPost = data.expanded;
+		var pv, box, x, y, inPost = data.expanded;
 		data.expanded = false;
 		if(nav.Firefox && this._isPview) {
 			box = this.el.getBoundingClientRect();


### PR DESCRIPTION
Улучшено раскрытие изображений в посте. Особенно заметно на крауте и ханабире при использовании функции "раскрыть все изображения". Был реквест в куклотреде. Плюс очистил функцию `_removeFullImage` для превьюшек.
