### PR TITLE
Рефакторинг кода скрытия постов

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -3797,7 +3797,7 @@ Spells.prototype = {
 		} else {
 			rType = type;
 		}
-		opt = val[2] && [val[2], val[4] ? val[4] : val[3] ? -1 : false];
+		opt = val[2] ? [val[2], val[4] ? val[4] : val[3] ? -1 : false] : null;
 		str = str.substr(offset + 1 + val[0].length);
 		temp = str[0] !== '(' ? 0 : str[1] === ')' ? 2 : false;
 		noBkt = temp !== false;


### PR DESCRIPTION
Фффух. А то совсем пиздец с кодом был. Теперь скрипт (наконец-то!) нормально будет работать с удалёнными постами. Алсо, теперь скрипт будет сохранять вместе со списком скрытых от спеллов постов номер последнего неудалённого поста в треде и его индекс. Если при обновлении треда этого поста не будет, либо его индекс не будет совпадать, то проверка спеллов проводится для всех постов.
