### PR TITLE
Исправление ошибки в AJAX-обновлении треда

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -9417,7 +9417,7 @@ function initThreadUpdater(title, enableUpdater) {
 			lastECode = 200;
 			setState('on');
 			checked404 = false;
-			if(lPosts === 0 && !Cfg['noErrInTitle']) {
+			if((focused || lPosts === 0) && !Cfg['noErrInTitle']) {
 				updateTitle();
 			}
 		}


### PR DESCRIPTION
Номера ошибок не пропадали из заголовков, если тред был в фокусе.
