### PR TITLE
Фиксы

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -8045,9 +8045,9 @@ function setPviewPosition(link, pView, animFun) {
 		offY = cr.top + window.pageYOffset,
 		bWidth = doc.documentElement.clientWidth,
 		isLeft = offX < bWidth / 2,
-		tmp = (isLeft ? (bWidth - offX) : offX) - 10,
-		lmw = 'max-width:' + tmp + 'px; left:' + (isLeft ? offX : offX -
-			Math.min(parseInt(pView.offsetWidth, 10), tmp)) + 'px;';
+		tmp = (isLeft ? offX : offX -
+			Math.min(parseInt(pView.offsetWidth, 10), offX - 10)),
+		lmw = 'max-width:' + (bWidth - tmp - 10) + 'px; left:' + tmp + 'px;';
 	if(animFun) {
 		oldCSS = pView.style.cssText;
 		pView.style.cssText = 'opacity: 0; ' + lmw;


### PR DESCRIPTION
**Fix expanded images width to prevent horizontal scrollbar**
В хроме и файрфоксе на дваче при раскрытии картинок в посте со включенной опцией "Уменьшать в экран большие изображения" появлялись горизонтальные скроллбары (в опере 12.16 скроллбар не появлялся, по страница по факсу становилась шире видимой части окна), чего быть не должно. Пофикшено.
**Fix pView max-width when isLeft==false**
Когда превьюха поста раскрывалась влево, при раскрытии картинок (в посте) те вылезали за границы превью из-за неправильно подсчитанного max-width. Пофикшено.
