### PR TITLE
File inputs и HTML5-постинг Краутчана

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -2812,10 +2812,10 @@ function getSubmitResponse(dc, isFrame) {
 
 function checkUpload(response) {
 	if(aib.krau) {
-		$id('postform').action=$id('postform').action.split('?')[0];
+		pr.form.action=pr.form.action.split('?')[0];
 		$id('postform_row_progress').setAttribute('style', 'display: none;');
 		doc.body.insertAdjacentHTML('beforeend', '<div style="display: none;" onclick="window.lastUpdateTime = 0"></div>');
-		var el = doc.body.lastChild; el.click(); el.remove();
+		var el = doc.body.lastChild; el.click(); $del(el);
 	}
 	var err = response[1];
 	if(err) {
@@ -2836,11 +2836,11 @@ function checkUpload(response) {
 			if(fileInputs.length > 1) {
 				$each(fileInputs, function(input, index) {
 					if(index > 0) {
-						input.parentNode.remove();
+						$del(input.parentNode);
 					}
 				});
 				doc.body.insertAdjacentHTML('beforeend', '<div style="display: none;" onclick="window.fileCounter = 1"></div>');
-				var el = doc.body.lastChild; el.click(); el.remove();
+				var el = doc.body.lastChild; el.click(); $del(el);
 			}
 		}
 	}
@@ -5741,7 +5741,7 @@ PostForm.processInput = function() {
 						if(index > current)
 							input.name = "file_" + (index-1);
 					});
-					this.parentNode.remove();
+					$del(this.parentNode);
 					if($q('input[type="file"]', $id('files_parent').lastElementChild).value) {
 						setTimeout(function(){PostForm.eventFiles($id('files_parent'));}, 100);
 					}
@@ -6252,13 +6252,13 @@ PostForm.prototype = {
 		}
 		if(Cfg['ajaxReply'] === 2) {
 			if(aib.krau) {
-				$id('postform').setAttribute('onsubmit', 'return(false)');
+				this.form.removeAttribute('onsubmit');
 			}
 			this.form.onsubmit = function(e) {
 				$pd(e);
 				if(aib.krau) {
 					doc.body.insertAdjacentHTML('beforeend', '<div style="display: none;" onclick="setupProgressTracking()"></div>');
-					var el = doc.body.lastChild; el.click(); el.remove();
+					var el = doc.body.lastChild; el.click(); $del(el);
 				}
 				new html5Submit(this.form, this.subm, checkUpload);
 			}.bind(this);


### PR DESCRIPTION
_Во, наконец-то, только мои коммиты в пулл-реквесте._
Реквесты из #552.
Убрал `unsafeWindow`. Допилил HTML5-постинг на краутчане (с поддержкой их симпатичного прогрессбара) с ресетом сопутствующих переменных, а также удаление лишних файл-инпутов (кнопка тоже не должна блочиться).
Тестировал нативно в Хроме, в Хроме с Тамперманки и в Файрфоксе, работает.
