### PR TITLE
Фиксы

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -6714,7 +6714,7 @@ ImgBtnsShowHider.prototype = {
 	},
 	_setHideTmt: function() {
 		clearTimeout(this._hideTmt);
-		this._hideTmt = setTimeout(this._hide().bind(this), 2000);
+		this._hideTmt = setTimeout(this._hide.bind(this), 2000);
 	},
 	_show: function() {
 		if(this._hidden) {
@@ -6732,8 +6732,8 @@ function ImageMover(img) {
 	img.addEventListener('mousedown', this, false);
 }
 ImageMover.prototype = {
-	_oldX: null,
-	_oldY: null,
+	_oldX: 0,
+	_oldY: 0,
 	moved: false,
 	handleEvent: function(e) {
 		switch(e.type) {


### PR DESCRIPTION
В Хроме уже больше года есть [баг: `mousemove` вызывается, даже если курсор стоит на месте](http://code.google.com/p/chromium/issues/detail?id=170631). Из-за этого бага в Хроме картинка по центру не всегда закрывалась с первого раза, и кнопки следующей/предыдущей картинки постоянно появлялись после пропадания.
Добавил сравнение с предыдущими координатами, чтоб фильтровать ложно-положительные срабатывания. Фиксит #574.
