### PR TITLE
Make ajax-updater not to treat http-code 304 as an error.

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -4034,7 +4034,7 @@ function loadPages(count) {
 }
 
 function infoLoadErrors(eCode, eMsg, newPosts) {
-	if(eCode === 200) {
+	if(eCode === 200 || eCode === 304) {
 		closeAlert($id('de-alert-newposts'));
 	} else if(eCode === 0) {
 		$alert(eMsg || Lng.noConnect[lang], 'newposts', false);


### PR DESCRIPTION
В треде жалуются, что на ычане в Опере (как минимум), при (авто-)обновлении постов выскакивает "ошибка" 304. Я думаю, что ычан выдает 304 при отсутствии новых постов, так что не следует при этом выдавать ошибку, которая мозолит глаза операюзерам.
