### PR TITLE
Fix focus/blur behavior

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -9784,24 +9784,13 @@ function initThreadUpdater(title, enableUpdate) {
 		favIntrv = 0;
 		favNorm = notifGranted = inited = true;
 		favHref = ($q('head link[rel="shortcut icon"]', doc) || {}).href;
-		if(('hidden' in doc) || ('webkitHidden' in doc)) {
-			focused = !(doc.hidden || doc.webkitHidden);
-			doc.addEventListener((nav.WebKit ? 'webkit' : '') + 'visibilitychange', function() {
-				if(doc.hidden || doc.webkitHidden) {
-					onBlur();
-				} else {
-					onVis();
-				}
-			}, false);
-		} else {
-			focused = false;
-			window.addEventListener('focus', onVis, false);
-			window.addEventListener('blur', onBlur, false);
-			window.addEventListener('mousemove', function mouseMove() {
-				window.removeEventListener('mousemove', mouseMove, false);
-				onVis();
-			}, false);
-		}
+		focused = false;
+		window.addEventListener('focus', onVis, false);
+		window.addEventListener('blur', onBlur, false);
+		window.addEventListener('mousemove', function mouseMove() {
+			window.removeEventListener('mousemove', mouseMove, false);
+			onVis();
+		}, false);
 		enable();
 	}
 


### PR DESCRIPTION
1. На опере 12.16 при минимизации окна не вызывается событие visibilitychange (и при этом `document.hidden` становится равным `undefined`).
2. Тред переходит в "несфокусированный" режим только при переключении вкладки или минимизации окна, что лично мне было не очень удобно, потому что я обычно переключаюсь с браузера на другие окна через `Alt+Tab` и при этом хочу, чтоб работал индикатор новых сообщений в треде.

Поэтому я сделал, чтоб тред переходил в "несфокусированный" режим при переключении вкладки, минимизации браузера **и** после переключение окна браузера на другое через `Alt+Tab`.
Проверил на ФФ со Скриптишом, на Хроме нативно и через Тамперманки, на Опере 12.16 нативно и через Вайлентманки - везде работает.
Анон в треде рапортует, что на Сафари в макоси это тоже работает и даже фиксит какой-то баг.
