### PR TITLE
Фиксы

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -1128,9 +1128,8 @@ function addPanel() {
 					(!aib.nul && !aib.abu && (!aib.fch || aib.arch) ? '' :
 						pButton('catalog', '//' + aib.host + '/' + (aib.abu ?
 							'makaba/makaba.fcgi?task=catalog&board=' + brd : brd + '/catalog.html'), false)) +
-					pButton('enable', '#', false) +
-					(!TNum && !aib.arch? '' :
-						(nav.Opera || nav.noBlob ? '' : pButton('imgload', '#', false)) +
+					(!TNum && !aib.arch? pButton('enable', '#', false) :
+						(nav.Opera || nav.noBlob ? '' : pButton('imgload', '#', false)) + pButton('enable', '#', false) +
 						'<div id="de-panel-info"><span title="' + Lng.panelBtn['counter'][lang] +
 							'">' + firstThr.pcount + '/' + imgLen + '</span></div>')
 				) +


### PR DESCRIPTION
Название коммитов отражают их суть, добавлю пару слов только про e891c97:
Если первый пост с картинкой с номером >4 скрыт, то при раскрытии всех изображений в `Post.sizing.getOffset` для скрытой картинки `el.getBoundingClientRect().left` выдает нуль, что есть баг, поэтому я сделал, чтоб скрытый пост показывался, прежде чем считать этот оффсет, а потом опять прятался.
