### PR TITLE
Make tab title not to show 304

### DIFF
--- a/Dollchan_Extension_Tools.user.js
+++ b/Dollchan_Extension_Tools.user.js
@@ -9966,7 +9966,7 @@ function initThreadUpdater(title, enableUpdate) {
 		}
 		currentXHR = null;
 		infoLoadErrors(eCode, eMsg, -1);
-		if(eCode !== 200) {
+		if(eCode !== 200 && eCode !== 304) {
 			lastECode = eCode;
 			if(!Cfg['noErrInTitle']) {
 				updateTitle();


### PR DESCRIPTION
Чтоб не показывало `{304}` в заголовке, как у [этого анона](http://iichan.hk/b/src/1396971623463.png).
