### PR TITLE
Всегда сбрасывать чекбокс "спойлер" на приклепляемых пиках

### DIFF
--- a/src/Dollchan_Extension_Tools.es6.user.js
+++ b/src/Dollchan_Extension_Tools.es6.user.js
@@ -30,7 +30,7 @@
 'use strict';
 
 const version = '18.4.26.0';
-const commit = '77a1f59';
+const commit = '8d2a71e';
 
 /* ==[ DefaultCfg.js ]========================================================================================
                                                 DEFAULT CONFIG
@@ -9440,6 +9440,7 @@ class FileInput {
 		el.classList.remove('de-file-off');
 		el = el.firstChild.firstChild;
 		el.title = `${ fileName }, ${ (fileSize / 1024).toFixed(2) }KB`;
+		this._btnSpoil.checked = this._spoilEl.checked = false;
 		this._mediaEl = el = $aBegin(el, fileType.startsWith('video/') ?
 			'<video class="de-file-img" loop autoplay muted src=""></video>' :
 			'<img class="de-file-img" src="">');
@@ -9556,7 +9557,6 @@ class FileInput {
 				$hide(this._txtWrap);
 			}
 			if(this._spoilEl) {
-				this._btnSpoil.checked = this._spoilEl.checked;
 				$show(this._btnSpoil);
 			}
 			this._txtInput.classList.add('de-file-txt-noedit');

--- a/src/modules/FormFile.js
+++ b/src/modules/FormFile.js
@@ -285,6 +285,7 @@ class FileInput {
 		el.classList.remove('de-file-off');
 		el = el.firstChild.firstChild;
 		el.title = `${ fileName }, ${ (fileSize / 1024).toFixed(2) }KB`;
+		this._btnSpoil.checked = this._spoilEl.checked = false;
 		this._mediaEl = el = $aBegin(el, fileType.startsWith('video/') ?
 			'<video class="de-file-img" loop autoplay muted src=""></video>' :
 			'<img class="de-file-img" src="">');
@@ -401,7 +402,6 @@ class FileInput {
 				$hide(this._txtWrap);
 			}
 			if(this._spoilEl) {
-				this._btnSpoil.checked = this._spoilEl.checked;
 				$show(this._btnSpoil);
 			}
 			this._txtInput.classList.add('de-file-txt-noedit');

--- a/src/modules/Wrap.js
+++ b/src/modules/Wrap.js
@@ -6,7 +6,7 @@
 'use strict';
 
 const version = '18.4.26.0';
-const commit = '77a1f59';
+const commit = '8d2a71e';
 
 /* ==[ DefaultCfg.js ]== */
 /* ==[ Localization.js ]== */


### PR DESCRIPTION
Аргументы "за":
1. Чаще постишь картинки без спойлера, чем с ним.
2. Чекбокс спойлера не видно, если только не навести курсор на превьюшку.
3. После того, как один раз запостил пик под спойлером, чекбокс спойлера будет висеть чекнутым до тех пор, пока не запостишь пик без спойлера. Для этого надо вспомнить что он чекнутый.

Как фичереквест считай. Если нет, то нет.

З.Ы. Я заново форкнул реп, потому что тогда что-то там насвинячил жутко при попытке обновить форк, во что потом ты вляпался при попытке вмержить мой пулреквест. Больше так не буду.