### PR TITLE
[kohlchan.net] Local times and Unix timestamp

### DIFF
--- a/src/Dollchan_Extension_Tools.es6.user.js
+++ b/src/Dollchan_Extension_Tools.es6.user.js
@@ -13882,6 +13882,12 @@ class Thread {
 		if(aib.t && Cfg.markNewPosts) {
 			Post.addMark(el, false);
 		}
+		if(aib.kohlchan && (localStorage.getItem('unixFilenames') == 'true')){
+                    var postCollection = el.querySelectorAll("div.panelUploads");
+  		    for (var z = 0; z < postCollection.length; z++) {
+		        aib.kcUnixTimestamp(postCollection[z]);
+		    }
+                }
 		return post;
 	}
 	_checkBans(pBuilder) {
@@ -17438,6 +17444,30 @@ function getImageBoard(checkDomains, checkEngines) {
 		getSage(post) {
 			return !!$q('.sage', post).hasChildNodes();
 		}
+		kcUnixTimestamp(postFromCollection) {
+                    var timetext = postFromCollection.parentElement.parentElement.querySelectorAll("span.labelCreated")[0].textContent.replace(/-/g,"/");
+                    var someDate = new Date(timetext);
+                    timetext = someDate.getTime();
+                    var fake_precision = timetext % 999
+                    timetext = timetext + fake_precision;
+                    var img_imgLink = postFromCollection.querySelectorAll("a.imgLink:not(.unixLink)");
+
+                    for(var j = 0; j < img_imgLink.length; j++) {
+                        var org_text = img_imgLink[j].href;
+                        var extension;
+                        if (img_imgLink[j].parentElement.nodeName == "SPAN") {
+                            extension = img_imgLink[j].parentElement.parentElement.querySelectorAll("a.originalNameLink")[0].title.split('.').pop();
+                        } else {
+                            extension = img_imgLink[j].parentElement.querySelectorAll("a.originalNameLink")[0].title.split('.').pop();
+                        }
+                        if (j == 0 && img_imgLink.length == 1) {
+                            img_imgLink[j].href = org_text + "/" + timetext + "." + extension;
+                        } else {
+                            img_imgLink[j].href = org_text + "/" + timetext + "-" + j + "." + extension;
+                        }
+                        img_imgLink[j].classList.add("unixLink");  
+                    } 
+                }
 		init() {
 			if(!this.host.includes('nocsp.') && this.host.includes('kohlchan.net')) {
 				deWindow.location.assign(deWindow.location.href

--- a/src/Dollchan_Extension_Tools.es6.user.js
+++ b/src/Dollchan_Extension_Tools.es6.user.js
@@ -17449,6 +17449,11 @@ function getImageBoard(checkDomains, checkEngines) {
 				deWindow.location.reload();
 				return true;
 			}
+			if(locStorage.convertLocalTimes !== 'false') {
+				locStorage.convertLocalTimes = false;
+				deWindow.location.reload();
+				return true;
+			}
 			return super.init();
 		}
 	}

--- a/src/modules/BoardDetector.js
+++ b/src/modules/BoardDetector.js
@@ -1872,6 +1872,11 @@ function getImageBoard(checkDomains, checkEngines) {
 				deWindow.location.reload();
 				return true;
 			}
+			if(locStorage.convertLocalTimes !== 'false') {
+				locStorage.convertLocalTimes = false;
+				deWindow.location.reload();
+				return true;
+			}
 			return super.init();
 		}
 	}

--- a/src/modules/BoardDetector.js
+++ b/src/modules/BoardDetector.js
@@ -1861,6 +1861,30 @@ function getImageBoard(checkDomains, checkEngines) {
 		getSage(post) {
 			return !!$q('.sage', post).hasChildNodes();
 		}
+		kcUnixTimestamp(postFromCollection) {
+                    var timetext = postFromCollection.parentElement.parentElement.querySelectorAll("span.labelCreated")[0].textContent.replace(/-/g,"/");
+                    var someDate = new Date(timetext);
+                    timetext = someDate.getTime();
+                    var fake_precision = timetext % 999
+                    timetext = timetext + fake_precision;
+                    var img_imgLink = postFromCollection.querySelectorAll("a.imgLink:not(.unixLink)");
+
+                    for(var j = 0; j < img_imgLink.length; j++) {
+                        var org_text = img_imgLink[j].href;
+                        var extension;
+                        if (img_imgLink[j].parentElement.nodeName == "SPAN") {
+                            extension = img_imgLink[j].parentElement.parentElement.querySelectorAll("a.originalNameLink")[0].title.split('.').pop();
+                        } else {
+                            extension = img_imgLink[j].parentElement.querySelectorAll("a.originalNameLink")[0].title.split('.').pop();
+                        }
+                        if (j == 0 && img_imgLink.length == 1) {
+                            img_imgLink[j].href = org_text + "/" + timetext + "." + extension;
+                        } else {
+                            img_imgLink[j].href = org_text + "/" + timetext + "-" + j + "." + extension;
+                        }
+                        img_imgLink[j].classList.add("unixLink");  
+                    } 
+                }
 		init() {
 			if(!this.host.includes('nocsp.') && this.host.includes('kohlchan.net')) {
 				deWindow.location.assign(deWindow.location.href

--- a/src/modules/Threads.js
+++ b/src/modules/Threads.js
@@ -258,6 +258,12 @@ class Thread {
 		if(aib.t && Cfg.markNewPosts) {
 			Post.addMark(el, false);
 		}
+		if(aib.kohlchan && (localStorage.getItem('unixFilenames') == 'true')){
+                    var postCollection = el.querySelectorAll("div.panelUploads");
+  		    for (var z = 0; z < postCollection.length; z++) {
+		        aib.kcUnixTimestamp(postCollection[z]);
+		    }
+                }
 		return post;
 	}
 	_checkBans(pBuilder) {


### PR DESCRIPTION
**Local times**
[Original comment](https://github.com/SthephanShinkufag/Dollchan-Extension-Tools/issues/1332#issuecomment-521555706)
[Example](https://files.catbox.moe/euh4ow.webm)
Dollchan has its own function that replaces post times with the local timezone.
However, Kohlchan already does that on first page load, if the "Local times" option is enabled, causing a conflict where some posts have the wrong timezone.
Dollchan should force that option to be disabled (just like the built-in auto updater is) so that it's the only script modifying post times.


**Unix timestamps**
[Original comment](https://github.com/SthephanShinkufag/Dollchan-Extension-Tools/issues/1332#issuecomment-522272723)
[Example before patch](https://files.catbox.moe/whtxwj.webm)
[Example after patch](https://files.catbox.moe/3iejpo.webm)
There's a setting (off by default) which generates unix-timestamp filenames and adds them to the end of upload urls using Javascript.
It doesn't conflict with Dollchan, but is only executed once, on initial pageload. Afterwards it is not executed anymore, because Dollchan replaces the built-in updater.
This patch simply takes the function from Kohlchan's [official scripts](https://gitgud.io/Tjark/KohlNumbra/-/blob/master/src/js/posting.js), and executes it when appropriate, _if_ the user has that setting enabled on KC. 