### PR TITLE
Compatibility with some vanilla Kohlchan settings

### DIFF
--- a/src/modules/BoardDetector.js
+++ b/src/modules/BoardDetector.js
@@ -1732,7 +1732,7 @@ function getImageBoard(checkDomains, checkEngines) {
 				deWindow.location.reload();
 				return true;
 			}
-			$Q('.imgLink').forEach(el => (el.className = 'de-img-link'));
+			$Q('.imgLink').forEach(el => (el.className = 'de-img-link imgLink'));
 			return super.init();
 		}
 	}


### PR DESCRIPTION
Some vanilla Kohlchan settings (unix timestamps, gallery mode) require that the "imgLink" class still be present. As long as that's the case, they work fine and don't interfere with Dollchan functionality.